### PR TITLE
Fix queue peek method and add tests

### DIFF
--- a/src/main/kotlin/basicStructures/queuesStacks/PriorityQueue.kt
+++ b/src/main/kotlin/basicStructures/queuesStacks/PriorityQueue.kt
@@ -13,6 +13,6 @@ class PriorityQueue<T: Comparable<T>> {
     }
 
     fun pop(): T = heap.remove() ?: throw NoSuchElementException("PriorityQueue is empty!")
-    fun peel(): T = heap.peek() ?: throw NoSuchElementException("PriorityQueue is empty!")
+    fun peek(): T = heap.peek() ?: throw NoSuchElementException("PriorityQueue is empty!")
     override fun toString(): String = heap.toString()
 }

--- a/src/main/kotlin/basicStructures/queuesStacks/Queue.kt
+++ b/src/main/kotlin/basicStructures/queuesStacks/Queue.kt
@@ -17,7 +17,7 @@ class Queue<T> {
         return elements.removeAt(0)
     }
 
-    fun peel(): T {
+    fun peek(): T {
         if (isEmpty()) {
             throw NoSuchElementException("Queue is empty!")
         }

--- a/src/test/kotlin/basicStructures/BasicStructuresTest.kt
+++ b/src/test/kotlin/basicStructures/BasicStructuresTest.kt
@@ -10,6 +10,8 @@ import org.example.basicStructures.linearStructures.arrays.*
 import basicStructures.linearStructures.lists.linkedList.*
 import basicStructures.linearStructures.lists.doublyLinkedList.*
 import org.example.basicStructures.linearStructures.lists.circularLinkedList.*
+import basicStructures.queuesStacks.Queue
+import org.example.basicStructures.queuesStacks.PriorityQueue
 
 
 class BasicStructuresTest {
@@ -104,6 +106,45 @@ class BasicStructuresTest {
             cll.insert(3)
             cll.delete(2)
             assertFalse(cll.contains(2))
+        }
+    }
+
+    @Nested
+    inner class QueueTest {
+        @Test fun `push pop and peek`() {
+            val queue = Queue<Int>()
+            queue.push(1)
+            queue.push(2)
+            assertEquals(1, queue.peek())
+            assertEquals(2, queue.size())
+            assertEquals(1, queue.pop())
+            assertEquals(1, queue.size())
+        }
+
+        @Test fun `empty queue throws`() {
+            val queue = Queue<Int>()
+            assertFailsWith<NoSuchElementException> { queue.pop() }
+            assertFailsWith<NoSuchElementException> { queue.peek() }
+        }
+    }
+
+    @Nested
+    inner class PriorityQueueTest {
+        @Test fun `push pop and peek`() {
+            val pq = PriorityQueue<Int>()
+            pq.push(3)
+            pq.push(1)
+            pq.push(2)
+            assertEquals(1, pq.peek())
+            assertEquals(3, pq.size())
+            assertEquals(1, pq.pop())
+            assertEquals(2, pq.peek())
+        }
+
+        @Test fun `empty priority queue throws`() {
+            val pq = PriorityQueue<Int>()
+            assertFailsWith<NoSuchElementException> { pq.pop() }
+            assertFailsWith<NoSuchElementException> { pq.peek() }
         }
     }
 }


### PR DESCRIPTION
## Summary
- correct the method name `peel()` -> `peek()` in `Queue` and `PriorityQueue`
- add unit tests covering queue and priority queue behavior

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684006df52bc832993ab0ecac4824c14