### PR TITLE
Handle duplicates in BinaryTree

### DIFF
--- a/src/main/kotlin/basicStructures/trees/binaryTree/BinaryTree.kt
+++ b/src/main/kotlin/basicStructures/trees/binaryTree/BinaryTree.kt
@@ -18,15 +18,12 @@ class BinaryTree<T: Comparable<T>> {
                     insertRec(current.left!!, newTreeNode)
                 }
             }
-            newTreeNode.value > current.value -> {
+            else -> { // newTreeNode.value >= current.value
                 if (current.right == null) {
                     current.right = newTreeNode
                 } else {
                     insertRec(current.right!!, newTreeNode)
                 }
-            }
-            else -> {
-                throw Exception("This value is already in Tree!")
             }
         }
     }

--- a/src/test/kotlin/algorithms/sortingAlgorithms/SortingAlgorithms.kt
+++ b/src/test/kotlin/algorithms/sortingAlgorithms/SortingAlgorithms.kt
@@ -61,4 +61,11 @@ class SortingAlgorithmsTest {
     @Test fun `TimSort sorts`()                     = runSortTest { TimSort.sort(it) }
     @Test fun `TournamentSort sorts`()              = runSortTest { TournamentSort.sort(it) }
     @Test fun `TreeSort sorts`()                    = runSortTest { TreeSort.sort(it) }
+
+    @Test fun `TreeSort sorts list with duplicates`() {
+        val original = mutableListOf(3, 1, 4, 3, 2, 2, 1)
+        val expected = original.sorted()
+        TreeSort.sort(original)
+        assertEquals(expected, original)
+    }
 }


### PR DESCRIPTION
## Summary
- allow BinaryTree to store duplicate values instead of throwing an exception
- add test verifying TreeSort correctly sorts lists with duplicates

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6840096a839c83299363cc238e9a9ca8